### PR TITLE
Upgrade libcurl to latest for streaming plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN ./dependencies.sh
 RUN ./extras.sh
 # Install libsrtp 2.0.0 (To reduce risk of broken interoperability with future WebRTC versions)
 RUN ./libsrtp.sh
+# Upgrade libcurl to 7.50.2 for streaming plugin support for RTSP
+RUN ./upgradelibcurl.sh
 # Install usrsctp for data channel support
 RUN ./usrsctp.sh
 # Install websocket dependencies

--- a/upgradecurl.sh
+++ b/upgradecurl.sh
@@ -1,0 +1,22 @@
+#! /usr/bin/env bash
+
+# Install any build dependencies needed for curl
+apt-get build-dep curl
+apt-get install wget
+
+# Get latest (as of Feb 25, 2016) libcurl
+mkdir ~/curl
+cd ~/curl
+wget http://curl.haxx.se/download/curl-7.50.2.tar.bz2
+tar -xvjf curl-7.50.2.tar.bz2
+cd curl-7.50.2
+
+# The usual steps for building an app from source
+./configure
+make
+make install
+
+# Resolve any issues of C-level lib
+# location caches ("shared library cache")
+ldconfig
+cd ..


### PR DESCRIPTION
The janus_streaming.c plugin needs libcurl libcurl >= 7.45.0 for rtsp. This PR upgrades libcurl to 7.50.2

This code could be added to "extras" or dependencies... but wanted to keep it simple. 

