### PR TITLE
Added missing libconfig dependancy

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -1,4 +1,4 @@
 apt-get install -y libmicrohttpd-dev libjansson-dev libnice-dev \
     libssl-dev libsofia-sip-ua-dev libglib2.0-dev \
     libopus-dev libogg-dev libini-config-dev libcollection-dev \
-    pkg-config gengetopt libtool automake
+    pkg-config gengetopt libtool automake libconfig-dev


### PR DESCRIPTION
Hi I recently built this docker repo for a project and noticed that it complained about a missing libconfig dependency. Thought I might hopefully be of help.